### PR TITLE
Use of startswith for is_xml_request method

### DIFF
--- a/automx2/views/__init__.py
+++ b/automx2/views/__init__.py
@@ -51,5 +51,5 @@ class MailConfig:
     @staticmethod
     def is_xml_request() -> bool:
         if CONTENT_TYPE in request.headers:
-            return request.headers[CONTENT_TYPE] == CONTENT_TYPE_XML or request.headers[CONTENT_TYPE] == 'text/xml'
+            return request.headers[CONTENT_TYPE].startswith(CONTENT_TYPE_XML) or request.headers[CONTENT_TYPE].startswith('text/xml')
         return False


### PR DESCRIPTION
Some clients (eg. Thunderbird 91.x) specifies charset in Content-Type header.

Therefore the request is rejected by automx2 because it doesn't EXACTLY matches.

Exemple POST from Thunderbird 91 sniffed with fiddler.
```
POST http://autodiscover.somedomain.com/autodiscover/autodiscover.xml HTTP/1.1
Host: autodiscover.somedomain.com
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Thunderbird/91.9.0
Accept: */*
Accept-Language: fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3
Accept-Encoding: gzip, deflate
Content-Type: text/xml; charset=utf-8
Content-Length: 394
Connection: keep-alive
```

Result in automx2log:
```
May 18 06:36:25 automx flask[26733]: x.x.x.x - - [18/May/2022 06:36:25] "POST /autodiscover/autodiscover.xml HTTP/1.0" 400 -
May 18 06:36:50 automx flask[26733]: Required content type is "application/xml"
```

Seems fine when using startswith.

PS: Yes, Thunderbird seems now to use autodiscover and it looks like it is checked BEFORE attempting their "legacy" autoconfig stuff... Can you confirm this ?
