### PR TITLE
Allow to configure user_name via seeding

### DIFF
--- a/automx2/database.py
+++ b/automx2/database.py
@@ -166,10 +166,12 @@ def populate_with_dict(config: dict) -> None:
             s = 'SSL'
         else:
             s = 'STARTTLS'
+        u = dictget_optional(server, 'user_name', "%EMAILADDRESS%")
         name = dictget_mandatory(server, 'name')
         servers.append(Server(
             id=sid, prio=prio, type=type_, port=port,
-            socket_type=s, name=name, domains=domains
+            socket_type=s, name=name, domains=domains,
+            user_name=u
         ))
         sid += 1
     sl = len(servers)

--- a/contrib/seed-example.json
+++ b/contrib/seed-example.json
@@ -2,8 +2,8 @@
   "provider": "Example Inc.",
   "domains": ["example.com", "example.net", "example.org"],
   "servers": [
-    {"type": "imap", "name": "imap.example.com"},
-    {"type": "smtp", "name": "smtp.example.com"},
+    {"type": "imap", "name": "imap.example.com", "user_name": "%EMAILADDRESS%"},
+    {"type": "smtp", "name": "smtp.example.com", "user_name": "%EMAILADDRESS%"},
     {"type": "caldav", "port": 443,
      "url": "https://www.example.net/SOGo/dav/%EMAILADDRESS%/Calendar/personal/"},
     {"type": "carddav", "port": 443,


### PR DESCRIPTION
I wanted to use `%EMAILLOCALPART%` without having to deal with a database and keep using the memory db.